### PR TITLE
Remove unused dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,11 +11,9 @@
     "xposttest": "istanbul check-coverage --statements 95 --branches 80"
   },
   "dependencies": {
-    "async": "^1.4.2",
     "istanbul-lib-coverage": "^1.0.0-alpha",
     "mkdirp": "^0.5.1",
     "path-parse": "^1.0.5",
-    "rimraf": "^2.4.3",
     "supports-color": "^3.1.2"
   },
   "devDependencies": {
@@ -23,7 +21,8 @@
     "coveralls": "^2.11.4",
     "istanbul": "^0.4.0",
     "jshint": "^2.8.0",
-    "mocha": "^2.3.3"
+    "mocha": "^2.3.3",
+    "rimraf": "^2.4.3"
   },
   "license": "BSD-3-Clause",
   "bugs": {


### PR DESCRIPTION
- `rimraf` is now a devDependency, since it's only used in tests.
- `async` is removed, since it's never used.